### PR TITLE
Fix imports for type-only modules

### DIFF
--- a/flexibudget/src/components/categories/CategoryForm.tsx
+++ b/flexibudget/src/components/categories/CategoryForm.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { categorySchema, CategoryFormData } from './categorySchema';
+import { categorySchema } from './categorySchema';
+import type { CategoryFormData } from './categorySchema';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Category } from '../../types/Category';
+import type { Category } from '../../types/Category';
 
 interface CategoryFormProps {
   categoryToEdit?: Category | null;

--- a/flexibudget/src/components/categories/CategoryList.tsx
+++ b/flexibudget/src/components/categories/CategoryList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useCategoryStore } from '../../stores/categoryStore';
 import { useTransactionStore } from '../../stores/transactionStore';
-import { Category } from '../../types/Category';
+import type { Category } from '../../types/Category';
 
 interface CategoryListProps {
   onEditCategory: (category: Category) => void;

--- a/flexibudget/src/components/transactions/TransactionForm.tsx
+++ b/flexibudget/src/components/transactions/TransactionForm.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { transactionSchema, TransactionFormData } from './transactionSchema';
+import { transactionSchema } from './transactionSchema';
+import type { TransactionFormData } from './transactionSchema';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Category } from '../../types/Category';
-import { Transaction } from '../../types/Transaction';
+import type { Category } from '../../types/Category';
+import type { Transaction } from '../../types/Transaction';
 
 interface TransactionFormProps {
   transactionToEdit?: Transaction | null;

--- a/flexibudget/src/components/transactions/TransactionList.tsx
+++ b/flexibudget/src/components/transactions/TransactionList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Transaction } from '../../types/Transaction';
+import type { Transaction } from '../../types/Transaction';
 
 interface TransactionListProps {
   onEditTransaction: (transaction: Transaction) => void;

--- a/flexibudget/src/pages/CategoriesPage.tsx
+++ b/flexibudget/src/pages/CategoriesPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import CategoryForm from '../components/categories/CategoryForm';
 import CategoryList from '../components/categories/CategoryList';
-import { Category } from '../types/Category'; // Importer Category
+import type { Category } from '../types/Category'; // Importer Category
 
 const CategoriesPage: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);

--- a/flexibudget/src/pages/DashboardPage.tsx
+++ b/flexibudget/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Doughnut, Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title } from 'chart.js';
+import type { TooltipItem } from 'chart.js';
 import { useTransactionStore } from '../stores/transactionStore';
 import { useCategoryStore } from '../stores/categoryStore';
 // Pas besoin d'importer Transaction ici car nous ne l'utilisons pas directement comme type de prop
@@ -62,7 +63,7 @@ const DashboardPage: React.FC = () => {
          },
          tooltip: {
              callbacks: {
-                 label: function(context: any) {
+                 label: function(context: TooltipItem<'doughnut'>) {
                      let label = context.label || '';
                      if (label) {
                          label += ': ';
@@ -115,7 +116,7 @@ const DashboardPage: React.FC = () => {
          },
          tooltip: {
              callbacks: {
-                 label: function(context: any) {
+                   label: function(context: TooltipItem<'bar'>) {
                      return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(context.parsed.y);
                  }
              }

--- a/flexibudget/src/pages/TransactionsPage.tsx
+++ b/flexibudget/src/pages/TransactionsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import TransactionForm from '../components/transactions/TransactionForm';
 import TransactionList from '../components/transactions/TransactionList';
-import { Transaction } from '../types/Transaction'; // Importer Transaction
+import type { Transaction } from '../types/Transaction'; // Importer Transaction
 
 const TransactionsPage: React.FC = () => {
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);

--- a/flexibudget/src/stores/categoryStore.ts
+++ b/flexibudget/src/stores/categoryStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Category } from '../types/Category';
+import type { Category } from '../types/Category';
 import { v4 as uuidv4 } from 'uuid';
 import { useTransactionStore } from './transactionStore';
 

--- a/flexibudget/src/stores/transactionStore.ts
+++ b/flexibudget/src/stores/transactionStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Transaction } from '../types/Transaction';
+import type { Transaction } from '../types/Transaction';
 import { v4 as uuidv4 } from 'uuid'; // Make sure to install uuid: npm install uuid && npm install --save-dev @types/uuid
 
 interface TransactionState {


### PR DESCRIPTION
## Summary
- mark interface imports as type-only so Vite doesn't try to load them at runtime
- type Chart.js tooltip callbacks to remove `any` usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842b197a5fc832fa14f713721706fab