### PR TITLE
Fix comment around category budget handling

### DIFF
--- a/flexibudget/src/components/categories/CategoryForm.tsx
+++ b/flexibudget/src/components/categories/CategoryForm.tsx
@@ -52,7 +52,8 @@ const CategoryForm: React.FC<CategoryFormProps> = ({ categoryToEdit, onFormClose
     if (data.type === 'expense' && data.budget !== undefined && data.budget > 0) {
       dataToSubmit.budget = data.budget;
     } else {
-      dataToSubmit.budget = undefined; // Assurez-vous que le budget est undefined si non applicable
+      // Assurez-vous que le budget est undefined si non applicable
+      dataToSubmit.budget = undefined;
     }
 
     if (categoryToEdit) {


### PR DESCRIPTION
## Summary
- clarify budget handling comment in CategoryForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842b7e34adc832fa31d2a57705997f6