### PR TITLE
Enable settings storage and local persistence

### DIFF
--- a/flexibudget/src/components/categories/CategoryList.tsx
+++ b/flexibudget/src/components/categories/CategoryList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useCategoryStore } from '../../stores/categoryStore';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { Category } from '../../types/Category';
+import { useCurrencyFormatter } from '../../utils/format';
 
 interface CategoryListProps {
   onEditCategory: (category: Category) => void;
@@ -13,6 +14,7 @@ const CategoryList: React.FC<CategoryListProps> = ({ onEditCategory }) => {
      deleteCategory: state.deleteCategory,
   }));
   const transactions = useTransactionStore((state) => state.transactions);
+  const formatCurrency = useCurrencyFormatter();
 
   const getCategoryExpenses = (categoryId: string): number => {
      return transactions
@@ -59,8 +61,8 @@ const CategoryList: React.FC<CategoryListProps> = ({ onEditCategory }) => {
              {category.type === 'expense' && category.budget !== undefined && category.budget > 0 && (
                  <div>
                      <div className="flex justify-between text-sm text-gray-600 mb-1">
-                         <span>Dépensé: {spent.toFixed(2)}€</span>
-                         <span>Budget: {budget.toFixed(2)}€</span>
+                         <span>Dépensé: {formatCurrency(spent)}</span>
+                         <span>Budget: {formatCurrency(budget)}</span>
                      </div>
                      <div className="w-full bg-gray-200 rounded-full h-2.5">
                          <div 
@@ -70,7 +72,7 @@ const CategoryList: React.FC<CategoryListProps> = ({ onEditCategory }) => {
                      </div>
                      {progress > 100 && (
                          <p className="text-xs text-red-600 mt-1 text-right">
-                             Dépassement de {(spent - budget).toFixed(2)}€ ({(progress - 100).toFixed(1)}%)
+                             Dépassement de {formatCurrency(spent - budget)} ({(progress - 100).toFixed(1)}%)
                          </p>
                      )}
                  </div>

--- a/flexibudget/src/components/transactions/TransactionList.tsx
+++ b/flexibudget/src/components/transactions/TransactionList.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { useCategoryStore } from '../../stores/categoryStore';
 import { Transaction } from '../../types/Transaction';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { useCurrencyFormatter } from '../../utils/format';
 
 interface TransactionListProps {
   onEditTransaction: (transaction: Transaction) => void;
@@ -13,6 +15,23 @@ const TransactionList: React.FC<TransactionListProps> = ({ onEditTransaction }) 
     deleteTransaction: state.deleteTransaction,
   }));
   const getCategoryById = useCategoryStore((state) => state.getCategoryById);
+  const dateFormat = useSettingsStore(state => state.dateFormat);
+  const formatCurrency = useCurrencyFormatter();
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const yyyy = date.getFullYear();
+    const mm = (date.getMonth() + 1).toString().padStart(2, '0');
+    const dd = date.getDate().toString().padStart(2, '0');
+    switch (dateFormat) {
+      case 'MM/dd/yyyy':
+        return `${mm}/${dd}/${yyyy}`;
+      case 'yyyy-MM-dd':
+        return `${yyyy}-${mm}-${dd}`;
+      default:
+        return `${dd}/${mm}/${yyyy}`;
+    }
+  };
 
   if (transactions.length === 0) {
     return (
@@ -40,12 +59,12 @@ const TransactionList: React.FC<TransactionListProps> = ({ onEditTransaction }) 
                     {category?.name || <span className="text-gray-500 italic">Non Catégorisé</span>}
                   </p>
                   <p className="text-xs text-gray-500 mt-1">
-                    Date: {new Date(transaction.date).toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    Date: {formatDate(transaction.date)}
                   </p>
                 </div>
                 <div className="flex-shrink-0 ml-4 text-right">
                    <p className={`text-xl font-bold mb-2 ${transaction.type === 'income' ? 'text-green-700' : 'text-red-700'}`}>
-                     {transaction.type === 'income' ? '+' : '-'}{transaction.amount.toFixed(2)} €
+                     {transaction.type === 'income' ? '+' : '-'}{formatCurrency(transaction.amount)}
                    </p>
                    <div className="flex flex-col sm:flex-row sm:space-x-2 space-y-2 sm:space-y-0">
                     <button 

--- a/flexibudget/src/pages/DashboardPage.tsx
+++ b/flexibudget/src/pages/DashboardPage.tsx
@@ -3,6 +3,8 @@ import { Doughnut, Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title } from 'chart.js';
 import { useTransactionStore } from '../stores/transactionStore';
 import { useCategoryStore } from '../stores/categoryStore';
+import { useSettingsStore } from '../stores/settingsStore';
+import { useCurrencyFormatter } from '../utils/format';
 // Pas besoin d'importer Transaction ici car nous ne l'utilisons pas directement comme type de prop
 
 ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title);
@@ -12,6 +14,8 @@ const DashboardPage: React.FC = () => {
   const { getCategoryById } = useCategoryStore((state) => ({
      getCategoryById: state.getCategoryById,
   }));
+  const currency = useSettingsStore(state => state.currency);
+  const formatCurrency = useCurrencyFormatter();
 
   const expenseTransactions = transactions.filter(t => t.type === 'expense');
   const expenseByCategory: { [key: string]: number } = {};
@@ -68,7 +72,7 @@ const DashboardPage: React.FC = () => {
                          label += ': ';
                      }
                      if (context.parsed !== null) {
-                         label += new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(context.parsed);
+                         label += new Intl.NumberFormat('fr-FR', { style: 'currency', currency }).format(context.parsed);
                      }
                      return label;
                  }
@@ -116,24 +120,24 @@ const DashboardPage: React.FC = () => {
          tooltip: {
              callbacks: {
                  label: function(context: any) {
-                     return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(context.parsed.y);
+                     return new Intl.NumberFormat('fr-FR', { style: 'currency', currency }).format(context.parsed.y);
                  }
              }
          }
      },
      scales: {
-         y: { beginAtZero: true, ticks: { callback: value => `${value}€` } },
+         y: { beginAtZero: true, ticks: { callback: value => new Intl.NumberFormat('fr-FR', { style: 'currency', currency }).format(Number(value)) } },
          x: { grid: { display: false } }
      }
   };
   
   const balance = totalIncome - totalExpenses;
 
-  const SummaryCard: React.FC<{title: string, amount: number, colorClass: string, children?: React.ReactNode}> = 
-    ({ title, amount, colorClass, children }) => (
+const SummaryCard: React.FC<{title: string, amount: number, colorClass: string, children?: React.ReactNode}> =
+  ({ title, amount, colorClass, children }) => (
     <div className={`p-6 rounded-xl shadow-lg transition-all duration-300 hover:shadow-2xl ${colorClass}`}>
       <h2 className="text-lg font-semibold text-white mb-1">{title}</h2>
-      <p className="text-3xl font-bold text-white">{amount.toFixed(2)} €</p>
+      <p className="text-3xl font-bold text-white">{formatCurrency(amount)}</p>
       {children}
     </div>
   );

--- a/flexibudget/src/pages/SettingsPage.tsx
+++ b/flexibudget/src/pages/SettingsPage.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useSettingsStore } from '../stores/settingsStore';
 
 const SettingsPage: React.FC = () => {
-  // Pour l'instant, ces contrôles ne sont pas fonctionnels.
-  // Ils sont là pour illustrer la structure.
+  const { currency, dateFormat, setCurrency, setDateFormat } = useSettingsStore();
+  const [currencyValue, setCurrencyValue] = useState(currency);
+  const [dateFormatValue, setDateFormatValue] = useState(dateFormat);
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    alert('Les paramètres ne sont pas sauvegardés dans cette version de démonstration.');
+    setCurrency(currencyValue);
+    setDateFormat(dateFormatValue);
+    alert('Paramètres sauvegardés.');
   };
 
   return (
@@ -16,34 +21,34 @@ const SettingsPage: React.FC = () => {
           <label htmlFor="currency" className="block text-sm font-medium text-gray-700 mb-1">
             Devise Préférée
           </label>
-          <select 
-            id="currency" 
+          <select
+            id="currency"
             name="currency"
             className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            defaultValue="EUR" // Valeur par défaut
+            value={currencyValue}
+            onChange={(e) => setCurrencyValue(e.target.value)}
           >
             <option value="EUR">Euro (€)</option>
             <option value="USD">Dollar Américain ($)</option>
             <option value="GBP">Livre Sterling (£)</option>
           </select>
-          <p className="text-xs text-gray-500 mt-1">La modification de la devise n'est pas fonctionnelle pour le moment.</p>
         </div>
 
         <div className="mb-6">
           <label htmlFor="dateFormat" className="block text-sm font-medium text-gray-700 mb-1">
             Format de Date
           </label>
-          <select 
-            id="dateFormat" 
+          <select
+            id="dateFormat"
             name="dateFormat"
             className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            defaultValue="dd/MM/yyyy" // Valeur par défaut
+            value={dateFormatValue}
+            onChange={(e) => setDateFormatValue(e.target.value)}
           >
             <option value="dd/MM/yyyy">JJ/MM/AAAA</option>
             <option value="MM/dd/yyyy">MM/JJ/AAAA</option>
             <option value="yyyy-MM-dd">AAAA-MM-JJ</option>
           </select>
-          <p className="text-xs text-gray-500 mt-1">La modification du format de date n'est pas fonctionnelle pour le moment.</p>
         </div>
         
         {/* Plus de paramètres peuvent être ajoutés ici */}
@@ -53,7 +58,7 @@ const SettingsPage: React.FC = () => {
           className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50"
           // disabled // Décommenter si vous voulez le désactiver visuellement
         >
-          Sauvegarder les Paramètres (Non fonctionnel)
+          Sauvegarder les Paramètres
         </button>
       </form>
     </div>

--- a/flexibudget/src/stores/categoryStore.ts
+++ b/flexibudget/src/stores/categoryStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { Category } from '../types/Category';
 import { v4 as uuidv4 } from 'uuid';
 import { useTransactionStore } from './transactionStore';
@@ -11,32 +12,37 @@ interface CategoryState {
   getCategoryById: (id: string) => Category | undefined;
 }
 
-export const useCategoryStore = create<CategoryState>((set, get) => ({
-  categories: [],
-  addCategory: (categoryData) => // categoryData peut inclure budget
-    set((state) => ({
-      categories: [...state.categories, { ...categoryData, id: uuidv4() }],
-    })),
-  updateCategory: (id, updatedCategoryData) => // updatedCategoryData peut inclure budget
-    set((state) => ({
-      categories: state.categories.map((c) =>
-        c.id === id ? { ...c, ...updatedCategoryData } : c
-      ),
-    })),
-  deleteCategory: (id) => {
-    const transactions = useTransactionStore.getState().transactions;
-    const isCategoryUsed = transactions.some(t => t.categoryId === id);
+export const useCategoryStore = create<CategoryState>()(
+  persist(
+    (set, get) => ({
+      categories: [],
+      addCategory: (categoryData) => // categoryData peut inclure budget
+        set((state) => ({
+          categories: [...state.categories, { ...categoryData, id: uuidv4() }],
+        })),
+      updateCategory: (id, updatedCategoryData) => // updatedCategoryData peut inclure budget
+        set((state) => ({
+          categories: state.categories.map((c) =>
+            c.id === id ? { ...c, ...updatedCategoryData } : c
+          ),
+        })),
+      deleteCategory: (id) => {
+        const transactions = useTransactionStore.getState().transactions;
+        const isCategoryUsed = transactions.some(t => t.categoryId === id);
 
-    if (isCategoryUsed) {
-      alert("Cette catégorie est utilisée par des transactions et ne peut pas être supprimée. Veuillez d'abord supprimer ou modifier les transactions associées.");
-      return false;
-    }
-    set((state) => ({
-      categories: state.categories.filter((c) => c.id !== id),
-    }));
-    return true;
-  },
-  getCategoryById: (id: string) => {
-     return get().categories.find(c => c.id === id);
-  }
-}));
+        if (isCategoryUsed) {
+          alert("Cette catégorie est utilisée par des transactions et ne peut pas être supprimée. Veuillez d'abord supprimer ou modifier les transactions associées.");
+          return false;
+        }
+        set((state) => ({
+          categories: state.categories.filter((c) => c.id !== id),
+        }));
+        return true;
+      },
+      getCategoryById: (id: string) => {
+         return get().categories.find(c => c.id === id);
+      }
+    }),
+    { name: 'categories' }
+  )
+);

--- a/flexibudget/src/stores/settingsStore.ts
+++ b/flexibudget/src/stores/settingsStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface SettingsState {
+  currency: string;
+  dateFormat: string;
+  setCurrency: (currency: string) => void;
+  setDateFormat: (format: string) => void;
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      currency: 'EUR',
+      dateFormat: 'dd/MM/yyyy',
+      setCurrency: (currency) => set({ currency }),
+      setDateFormat: (dateFormat) => set({ dateFormat }),
+    }),
+    { name: 'settings' }
+  )
+);

--- a/flexibudget/src/stores/transactionStore.ts
+++ b/flexibudget/src/stores/transactionStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { Transaction } from '../types/Transaction';
 import { v4 as uuidv4 } from 'uuid'; // Use uuid to generate unique transaction IDs
 
@@ -9,20 +10,25 @@ interface TransactionState {
   deleteTransaction: (id: string) => void;
 }
 
-export const useTransactionStore = create<TransactionState>((set) => ({
-  transactions: [],
-  addTransaction: (transaction) =>
-    set((state) => ({
-      transactions: [...state.transactions, { ...transaction, id: uuidv4() }],
-    })),
-  updateTransaction: (id, updatedTransaction) =>
-    set((state) => ({
-      transactions: state.transactions.map((t) =>
-        t.id === id ? { ...t, ...updatedTransaction } : t
-      ),
-    })),
-  deleteTransaction: (id) =>
-    set((state) => ({
-      transactions: state.transactions.filter((t) => t.id !== id),
-    })),
-}));
+export const useTransactionStore = create<TransactionState>()(
+  persist(
+    (set) => ({
+      transactions: [],
+      addTransaction: (transaction) =>
+        set((state) => ({
+          transactions: [...state.transactions, { ...transaction, id: uuidv4() }],
+        })),
+      updateTransaction: (id, updatedTransaction) =>
+        set((state) => ({
+          transactions: state.transactions.map((t) =>
+            t.id === id ? { ...t, ...updatedTransaction } : t
+          ),
+        })),
+      deleteTransaction: (id) =>
+        set((state) => ({
+          transactions: state.transactions.filter((t) => t.id !== id),
+        })),
+    }),
+    { name: 'transactions' }
+  )
+);

--- a/flexibudget/src/utils/format.ts
+++ b/flexibudget/src/utils/format.ts
@@ -1,0 +1,7 @@
+import { useSettingsStore } from '../stores/settingsStore';
+
+export const useCurrencyFormatter = () => {
+  const currency = useSettingsStore(state => state.currency);
+  return (amount: number) =>
+    new Intl.NumberFormat('fr-FR', { style: 'currency', currency }).format(amount);
+};


### PR DESCRIPTION
## Summary
- persist categories and transactions in localStorage
- add a settings store for currency and date format
- make the Settings page save user preferences
- format amounts/dates using saved preferences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842bb3b5028832f84aec22fbdd9e795