### PR TITLE
Use type-only imports

### DIFF
--- a/flexibudget/src/components/categories/CategoryForm.tsx
+++ b/flexibudget/src/components/categories/CategoryForm.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { categorySchema, CategoryFormData } from './categorySchema';
+import { categorySchema } from './categorySchema';
+import type { CategoryFormData } from './categorySchema';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Category } from '../../types/Category';
+import type { Category } from '../../types/Category';
 
 interface CategoryFormProps {
   categoryToEdit?: Category | null;

--- a/flexibudget/src/components/categories/CategoryList.tsx
+++ b/flexibudget/src/components/categories/CategoryList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useCategoryStore } from '../../stores/categoryStore';
 import { useTransactionStore } from '../../stores/transactionStore';
-import { Category } from '../../types/Category';
+import type { Category } from '../../types/Category';
 import { useCurrencyFormatter } from '../../utils/format';
 
 interface CategoryListProps {

--- a/flexibudget/src/components/transactions/TransactionForm.tsx
+++ b/flexibudget/src/components/transactions/TransactionForm.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import type { SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { transactionSchema, TransactionFormData } from './transactionSchema';
+import { transactionSchema } from './transactionSchema';
+import type { TransactionFormData } from './transactionSchema';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Category } from '../../types/Category';
-import { Transaction } from '../../types/Transaction';
+import type { Category } from '../../types/Category';
+import type { Transaction } from '../../types/Transaction';
 import { Link } from 'react-router-dom';
 
 interface TransactionFormProps {

--- a/flexibudget/src/components/transactions/TransactionList.tsx
+++ b/flexibudget/src/components/transactions/TransactionList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTransactionStore } from '../../stores/transactionStore';
 import { useCategoryStore } from '../../stores/categoryStore';
-import { Transaction } from '../../types/Transaction';
+import type { Transaction } from '../../types/Transaction';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useCurrencyFormatter } from '../../utils/format';
 

--- a/flexibudget/src/pages/CategoriesPage.tsx
+++ b/flexibudget/src/pages/CategoriesPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import CategoryForm from '../components/categories/CategoryForm';
 import CategoryList from '../components/categories/CategoryList';
-import { Category } from '../types/Category'; // Importer Category
+import type { Category } from '../types/Category'; // Importer Category
 
 const CategoriesPage: React.FC = () => {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);

--- a/flexibudget/src/pages/TransactionsPage.tsx
+++ b/flexibudget/src/pages/TransactionsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import TransactionForm from '../components/transactions/TransactionForm';
 import TransactionList from '../components/transactions/TransactionList';
-import { Transaction } from '../types/Transaction'; // Importer Transaction
+import type { Transaction } from '../types/Transaction'; // Importer Transaction
 
 const TransactionsPage: React.FC = () => {
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);

--- a/flexibudget/src/stores/categoryStore.ts
+++ b/flexibudget/src/stores/categoryStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Category } from '../types/Category';
+import type { Category } from '../types/Category';
 import { v4 as uuidv4 } from 'uuid';
 import { useTransactionStore } from './transactionStore';
 

--- a/flexibudget/src/stores/transactionStore.ts
+++ b/flexibudget/src/stores/transactionStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Transaction } from '../types/Transaction';
+import type { Transaction } from '../types/Transaction';
 import { v4 as uuidv4 } from 'uuid'; // Use uuid to generate unique transaction IDs
 
 interface TransactionState {


### PR DESCRIPTION
## Summary
- use `import type` for type-only imports in stores and components
- separate types from values when importing form schemas
- adjust forms to import `SubmitHandler` as a type

## Testing
- `npm run build`
- `npm test` *(fails to run to completion; tests pass in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_684308bc73a0832fab17781b3ab7c583