### PR TITLE
Fix TooltipItem import

### DIFF
--- a/flexibudget/src/pages/DashboardPage.tsx
+++ b/flexibudget/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Doughnut, Bar } from 'react-chartjs-2';
-import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title, TooltipItem } from 'chart.js';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement, Title } from 'chart.js';
+import type { TooltipItem } from 'chart.js';
 import { useTransactionStore } from '../stores/transactionStore';
 import { useCategoryStore } from '../stores/categoryStore';
 import { useSettingsStore } from '../stores/settingsStore';


### PR DESCRIPTION
## Summary
- declare `TooltipItem` as type import in dashboard page

## Testing
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_684318de78e8832f9acaf5816a2dfda9