### PR TITLE
Fix infinite rerender with Zustand selectors

### DIFF
--- a/flexibudget/src/components/categories/CategoryForm.tsx
+++ b/flexibudget/src/components/categories/CategoryForm.tsx
@@ -13,10 +13,8 @@ interface CategoryFormProps {
 }
 
 const CategoryForm: React.FC<CategoryFormProps> = ({ categoryToEdit, onFormClose }) => {
-  const { addCategory, updateCategory } = useCategoryStore(state => ({
-     addCategory: state.addCategory,
-     updateCategory: state.updateCategory
-  }));
+  const addCategory = useCategoryStore(state => state.addCategory);
+  const updateCategory = useCategoryStore(state => state.updateCategory);
   
   const { register, handleSubmit, formState: { errors }, reset, setValue, watch } = useForm<CategoryFormData>({
     resolver: zodResolver(categorySchema),

--- a/flexibudget/src/components/categories/CategoryList.tsx
+++ b/flexibudget/src/components/categories/CategoryList.tsx
@@ -9,10 +9,8 @@ interface CategoryListProps {
 }
 
 const CategoryList: React.FC<CategoryListProps> = ({ onEditCategory }) => {
-  const { categories, deleteCategory } = useCategoryStore((state) => ({
-     categories: state.categories,
-     deleteCategory: state.deleteCategory,
-  }));
+  const categories = useCategoryStore(state => state.categories);
+  const deleteCategory = useCategoryStore(state => state.deleteCategory);
   const transactions = useTransactionStore((state) => state.transactions);
   const formatCurrency = useCurrencyFormatter();
 

--- a/flexibudget/src/components/transactions/TransactionForm.tsx
+++ b/flexibudget/src/components/transactions/TransactionForm.tsx
@@ -16,10 +16,8 @@ interface TransactionFormProps {
 }
 
 const TransactionForm: React.FC<TransactionFormProps> = ({ transactionToEdit, onFormClose }) => {
-  const { addTransaction, updateTransaction } = useTransactionStore((state) => ({
-     addTransaction: state.addTransaction,
-     updateTransaction: state.updateTransaction,
-  }));
+  const addTransaction = useTransactionStore(state => state.addTransaction);
+  const updateTransaction = useTransactionStore(state => state.updateTransaction);
   const allCategories = useCategoryStore((state) => state.categories);
  
   const { register, handleSubmit, formState: { errors }, reset, watch, setValue } = useForm<TransactionFormData>({

--- a/flexibudget/src/components/transactions/TransactionList.tsx
+++ b/flexibudget/src/components/transactions/TransactionList.tsx
@@ -10,10 +10,8 @@ interface TransactionListProps {
 }
 
 const TransactionList: React.FC<TransactionListProps> = ({ onEditTransaction }) => {
-  const { transactions, deleteTransaction } = useTransactionStore((state) => ({
-    transactions: state.transactions,
-    deleteTransaction: state.deleteTransaction,
-  }));
+  const transactions = useTransactionStore(state => state.transactions);
+  const deleteTransaction = useTransactionStore(state => state.deleteTransaction);
   const getCategoryById = useCategoryStore((state) => state.getCategoryById);
   const dateFormat = useSettingsStore(state => state.dateFormat);
   const formatCurrency = useCurrencyFormatter();

--- a/flexibudget/src/pages/DashboardPage.tsx
+++ b/flexibudget/src/pages/DashboardPage.tsx
@@ -12,9 +12,7 @@ ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarEle
 
 const DashboardPage: React.FC = () => {
   const transactions = useTransactionStore((state) => state.transactions);
-  const { getCategoryById } = useCategoryStore((state) => ({
-     getCategoryById: state.getCategoryById,
-  }));
+  const getCategoryById = useCategoryStore(state => state.getCategoryById);
   const currency = useSettingsStore(state => state.currency);
   const formatCurrency = useCurrencyFormatter();
 

--- a/flexibudget/src/pages/SettingsPage.tsx
+++ b/flexibudget/src/pages/SettingsPage.tsx
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 import { useSettingsStore } from '../stores/settingsStore';
 
 const SettingsPage: React.FC = () => {
-  const { currency, dateFormat, setCurrency, setDateFormat } = useSettingsStore();
+  const currency = useSettingsStore(state => state.currency);
+  const dateFormat = useSettingsStore(state => state.dateFormat);
+  const setCurrency = useSettingsStore(state => state.setCurrency);
+  const setDateFormat = useSettingsStore(state => state.setDateFormat);
   const [currencyValue, setCurrencyValue] = useState(currency);
   const [dateFormatValue, setDateFormatValue] = useState(dateFormat);
 


### PR DESCRIPTION
## Summary
- select store properties individually instead of returning objects
- use consistent selectors in forms and pages to avoid loops

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68431a3173d4832fbced8387e3e63cc2