### PR TITLE
Add dark mode toggle

### DIFF
--- a/flexibudget/src/App.tsx
+++ b/flexibudget/src/App.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import NavigationBar from './components/NavigationBar';
 import DashboardPage from './pages/DashboardPage';
 import TransactionsPage from './pages/TransactionsPage';
 import CategoriesPage from './pages/CategoriesPage';
 import SettingsPage from './pages/SettingsPage'; // Importer la nouvelle page
-import './index.css'; 
+import './index.css'
+import { useSettingsStore } from './stores/settingsStore'
 
 const App: React.FC = () => {
+  const theme = useSettingsStore((state) => state.theme)
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', theme === 'dark')
+  }, [theme])
+
   return (
     <Router>
       {/* Utilisation des classes de ma version précédente pour le style général */}

--- a/flexibudget/src/components/NavigationBar.tsx
+++ b/flexibudget/src/components/NavigationBar.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom'; // useLocation pour le lien actif
+import React from 'react'
+import { Link, useLocation } from 'react-router-dom' // useLocation pour le lien actif
+import { useSettingsStore } from '../stores/settingsStore'
 
 const NavigationBar: React.FC = () => {
   const location = useLocation();
+  const theme = useSettingsStore((state) => state.theme)
+  const setTheme = useSettingsStore((state) => state.setTheme)
+
+  const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light')
 
   const linkClasses = (path: string) => 
     `px-3 py-2 rounded-md text-sm font-medium transition-colors duration-150 ease-in-out ${
@@ -47,6 +52,12 @@ const NavigationBar: React.FC = () => {
               <Link to="/settings" className={linkClasses('/settings')}>
                 Paramètres
               </Link>
+              <button
+                onClick={toggleTheme}
+                className="px-3 py-2 rounded-md text-sm font-medium text-indigo-100 hover:bg-indigo-500 hover:text-white focus:outline-none"
+              >
+                {theme === 'light' ? '🌙' : '☀️'}
+              </button>
             </div>
           </div>
           {/* Bouton Menu Mobile */}
@@ -81,6 +92,15 @@ const NavigationBar: React.FC = () => {
             <Link to="/transactions" className={mobileLinkClasses('/transactions')} onClick={() => setIsMobileMenuOpen(false)}>Transactions</Link>
             <Link to="/categories" className={mobileLinkClasses('/categories')} onClick={() => setIsMobileMenuOpen(false)}>Catégories</Link>
             <Link to="/settings" className={mobileLinkClasses('/settings')} onClick={() => setIsMobileMenuOpen(false)}>Paramètres</Link>
+            <button
+              onClick={() => {
+                toggleTheme()
+                setIsMobileMenuOpen(false)
+              }}
+              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-indigo-100 hover:bg-indigo-500 hover:text-white focus:outline-none"
+            >
+              {theme === 'light' ? 'Mode sombre' : 'Mode clair'}
+            </button>
           </div>
         </div>
       )}

--- a/flexibudget/src/stores/settingsStore.ts
+++ b/flexibudget/src/stores/settingsStore.ts
@@ -1,11 +1,15 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+type Theme = 'light' | 'dark'
+
 interface SettingsState {
-  currency: string;
-  dateFormat: string;
-  setCurrency: (currency: string) => void;
-  setDateFormat: (format: string) => void;
+  currency: string
+  dateFormat: string
+  theme: Theme
+  setCurrency: (currency: string) => void
+  setDateFormat: (format: string) => void
+  setTheme: (theme: Theme) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -13,8 +17,10 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       currency: 'EUR',
       dateFormat: 'dd/MM/yyyy',
+      theme: 'light',
       setCurrency: (currency) => set({ currency }),
       setDateFormat: (dateFormat) => set({ dateFormat }),
+      setTheme: (theme) => set({ theme }),
     }),
     { name: 'settings' }
   )

--- a/flexibudget/tailwind.config.js
+++ b/flexibudget/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- manage theme state in settings store
- allow theme switch from NavigationBar
- apply `dark` class on `<body>` when activated
- use Tailwind CSS class-based dark mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68432281ba20832fa56ea43f5579d2f1