### PR TITLE
Rendre le champ description optionnel pour les transactions

### DIFF
--- a/src/components/AddTransactionForm.tsx
+++ b/src/components/AddTransactionForm.tsx
@@ -15,7 +15,7 @@ const transactionSchema = z.object({
   categoryId: z.string().min(1, "Veuillez sélectionner une catégorie."),
   amount: z.coerce.number().positive({ message: "Le montant doit être un nombre positif." }),
   date: z.string().min(1, { message: "La date est requise." }),
-  description: z.string().min(3, { message: "La description doit contenir au moins 3 caractères." }),
+  description: z.string().optional(),
 }).refine(data => data.type === 'revenu' || (data.type === 'depense' && !!data.pillar), {
   message: "Veuillez sélectionner un pilier.",
   path: ["pillar"],

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -108,7 +108,7 @@ const TransactionsPage = () => {
                   <div 
                     key={transaction.id}
                     className={`p-1 text-xs rounded text-white truncate ${transaction.type === 'revenu' ? 'bg-brand-revenu' : 'bg-red-500'}`}
-                    title={`${getCategoryNameById(transaction.categoryId)}: ${transaction.description} - ${transaction.amount.toLocaleString('fr-FR', {style: 'currency', currency})}`}
+                    title={`${getCategoryNameById(transaction.categoryId)}${transaction.description ? `: ${transaction.description}` : ''} - ${transaction.amount.toLocaleString('fr-FR', {style: 'currency', currency})}`}
                   >
                     {getCategoryNameById(transaction.categoryId)}
                   </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,6 @@
 // Définit les trois piliers possibles pour une catégorie de dépense
 export type Pillar = 'Besoins' | 'Envies' | 'Épargne';
 
-// Définit la structure d'une transaction
-export interface Transaction {
-  id: string;
-  type: 'revenu' | 'depense';
-  amount: number;
-  date: string; // Pour la simplicité, on utilise une string (ex: "2024-06-15")
-  description: string;
-  pillar?: Pillar; // Le pilier est optionnel, car un revenu n'en a pas
-}
-
 // Définit la structure d'une catégorie de dépense
 export interface Category {
   id: string;
@@ -25,7 +15,7 @@ export interface Transaction {
   type: 'revenu' | 'depense';
   amount: number;
   date: string;
-  description: string;
+  description?: string; // Made optional
   categoryId?: string; // <-- MODIFIÉ : On stocke l'ID de la catégorie
   pillar?: Pillar; // On garde pillar optionnel, mais il sera ajouté par le store
 }


### PR DESCRIPTION
Ce commit modifie le comportement du champ "description" pour les transactions :

- Le champ "description" dans le formulaire d'ajout/modification n'est plus obligatoire. Vous pouvez désormais créer ou mettre à jour des transactions sans fournir de description.
- La validation Zod et les types TypeScript ont été mis à jour pour refléter que la description est optionnelle.
- L'affichage des transactions (panneau de détails et tooltip du calendrier) a été ajusté pour gérer correctement les descriptions absentes, en évitant d'afficher des placeholders indésirables ou des formatages incorrects.
- Une définition de type Transaction dupliquée a été supprimée de `src/types/index.ts`.